### PR TITLE
issue #1 autoenv masks return value of builtin cd

### DIFF
--- a/autovenv.sh
+++ b/autovenv.sh
@@ -52,8 +52,7 @@ autovenv() {
 # wrap builtin cd command
 cd() {
     echo $@
-    builtin cd "$@"
-    autovenv
+    builtin cd "$@" && autovenv
 }
 
 # also run autovenv in a freshly created shell

--- a/autovenv.sh
+++ b/autovenv.sh
@@ -4,12 +4,15 @@ FN_AUTOVENV=.autovenv
 
 # recursively find a .autovenv file
 find-autovenv() {
-    local curdir=$(pwd)
+    local curdir
+    curdir=$(pwd)
+
     local path=
     
-    while [ ! $path ] 
+    while [ ! "$path" ] 
     do
-        local parent="$(dirname "$curdir")"
+        local parent
+        parent="$(dirname "$curdir")"
         
         if [ -e "$curdir/$FN_AUTOVENV" ]
         then
@@ -34,10 +37,12 @@ find-autovenv() {
 
 # handle logic to activate/deactivate virtualenvs
 autovenv() {
-    local venv_dir="$(find-autovenv)"
+    local venv_dir
+    venv_dir="$(find-autovenv)"
     if [ "$venv_dir" ]
     then
-        local venv_name=$(head -n 1 "$venv_dir/$FN_AUTOVENV")
+        local venv_name
+        venv_name=$(head -n 1 "$venv_dir/$FN_AUTOVENV")
         #echo "activating $venv_name"
         source "$venv_dir/$venv_name/bin/activate"
     else 
@@ -51,7 +56,7 @@ autovenv() {
 
 # wrap builtin cd command
 cd() {
-    echo $@
+    echo "$@"
     builtin cd "$@" && autovenv
 }
 


### PR DESCRIPTION
At autovenv.sh:53

cd() {
    echo $@
    builtin cd "$@"
    autovenv
}

autovenv is called regardless of whether or not builtin cd "$@" succeeds; this masks the return value of builtin cd. This breaks any checks for the return value of cd subsequent to sourcing autovenv.sh, e.g.

cd some/directory/that/does/not/exist && rm -rf important_directory/ will remove important_directory/ in the current directory because the call to builtin cd failed, but autovenv was called afterwards, and it apparently always returns true, so cd() is successful, even though builtin cd is not.

Making the call to autovenv conditional on the success of builtin cd will fix this:

cd() {
    echo $@
    builtin cd "$@" && autovenv
}